### PR TITLE
Add --source option and default to lastfm

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.2.0
+    rev: v2.4.4
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
@@ -9,13 +9,11 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-        language_version: python3.7
         # override until resolved: https://github.com/psf/black/issues/402
         files: \.pyi?$
         types: []
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.2
     hooks:
       - id: flake8
-        language_version: python3.7


### PR DESCRIPTION
Because bbcrealtime seems to have been turned off.

But keep it as an option because sometimes the BBC breaks scrobbling their radio stations to Last.fm, and maybe bbcrealtime will available then.